### PR TITLE
Add and use timestamp index for uncapped collections to preserve document order

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,8 @@ app.readStream = function(id, page) {
     mongo: this.db,
     id: id,
     page: parseInt(page),
-    pageSize: parseInt(this.pageSize)
+    pageSize: parseInt(this.pageSize),
+    cap: this.cap
   });
 
 };

--- a/lib/readable.js
+++ b/lib/readable.js
@@ -88,8 +88,15 @@ proto.attachStream = function(col) {
     this.page = 1;
   }
 
-  // reverse sort
-  query = col.find({}, {_id:0}).sort({'$natural': -1});
+  // reverse sort, on natural order if capped or timestamp if not
+  var sortOptions;
+  if (this.cap) {
+    sortOptions = {'$natural': -1};
+  } else {
+    sortOptions = {timestamp: -1};
+  }
+
+  query = col.find({}, {_id:0}).sort(sortOptions);
 
   if(! all) {
     query.skip((this.page - 1) * this.pageSize).limit(this.pageSize);

--- a/lib/writable.js
+++ b/lib/writable.js
@@ -104,6 +104,12 @@ proto.loadCollection = function(db) {
             return reject(err);
           }
 
+          // If the collection is not capped then we need an index on
+          // timestamp to ensure we can read documents in the correct order
+          if (!self.cap) {
+            col.createIndex({timestamp: 1});
+          }
+
           self.collection = col;
           self.loading = false;
           self.emit('loaded', col);


### PR DESCRIPTION
If the cap config value is 0, the MongoDB collection is uncapped.  Uncapped collections do not have a predictable natural order on disk so it doesn't work to sort on it in that case.  For uncapped collections, add an index on timestamp and sort on it when reading.
